### PR TITLE
fix token setting

### DIFF
--- a/preppal-fe/src/components/fav-button/fav-button.tsx
+++ b/preppal-fe/src/components/fav-button/fav-button.tsx
@@ -10,7 +10,7 @@ const FavouriteButton = (recipe: any) => {
     async function saveStatus(id: string) {
         const token = sessionStorage.getItem("token");
         let saved = false;
-        if (token) {
+        if (token && token !== "undefined") {
             const req = {
                 method: "POST",
 
@@ -30,7 +30,7 @@ const FavouriteButton = (recipe: any) => {
     async function updateSavedRecipes(saveRecipeId: string, save: boolean) {
         const token = sessionStorage.getItem("token");
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 if (save) {
                     const req = {
                         method: "POST",

--- a/preppal-fe/src/components/nav-bar/nav-bar.tsx
+++ b/preppal-fe/src/components/nav-bar/nav-bar.tsx
@@ -16,7 +16,7 @@ const NavBar = () => {
   const fillUserContent = async () => {
     const token = sessionStorage.getItem("token");
     try {
-      if (token) {
+      if (token !== "undefined") {
         setLoggedIn(true);
       }
     } catch (err) {

--- a/preppal-fe/src/pages/collections.tsx
+++ b/preppal-fe/src/pages/collections.tsx
@@ -18,7 +18,7 @@ const Collections = () => {
         const token = sessionStorage.getItem("token");
         let fetchedRecipes: any[] = [];
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "GET",
                     headers: {
@@ -39,7 +39,7 @@ const Collections = () => {
         const token = sessionStorage.getItem("token");
         let fetchedRecipes: any[] = [];
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "GET",
                     headers: {

--- a/preppal-fe/src/pages/create-recipe.tsx
+++ b/preppal-fe/src/pages/create-recipe.tsx
@@ -41,7 +41,7 @@ const CreateRecipe = () => {
     const getUser = async () => {
         const token = sessionStorage.getItem("token");
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "GET",
                     headers: {
@@ -67,7 +67,7 @@ const CreateRecipe = () => {
             e.preventDefault();
             const token = sessionStorage.getItem("token");
             try {
-                if (token) {
+                if (token && token !== "undefined") {
                     const req = {
                         method: "POST",
 

--- a/preppal-fe/src/pages/edit-profile.tsx
+++ b/preppal-fe/src/pages/edit-profile.tsx
@@ -28,7 +28,7 @@ function EditProfile() {
     const fillUserContent = async () => {
         const token = sessionStorage.getItem("token");
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "GET",
                     headers: {
@@ -56,7 +56,7 @@ function EditProfile() {
         const token = sessionStorage.getItem("token");
         try {
             //Using inputted userPassword, confirm user ID
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "POST",
 

--- a/preppal-fe/src/pages/profile.tsx
+++ b/preppal-fe/src/pages/profile.tsx
@@ -28,7 +28,7 @@ function Profile() {
         try {
             let res;
             if (myProfile) {
-                if (token) {
+                if (token && token !== "undefined") {
                     const req = {
                         method: "GET",
                         headers: {

--- a/preppal-fe/src/pages/recipe.tsx
+++ b/preppal-fe/src/pages/recipe.tsx
@@ -50,7 +50,7 @@ const Recipe = () => {
     const getUser = async () => {
         const token = sessionStorage.getItem("token");
         try {
-            if (token) {
+            if (token && token !== "undefined") {
                 const req = {
                     method: "GET",
                     headers: {


### PR DESCRIPTION
When we try to login and the attempt fails (because the password or username is incorrect) it tries to set the token with null. This ends up setting the token to be "undefined" not undefined (saved as a string). We should have an extra check to see that it is not "undefined"